### PR TITLE
proofs: exclude AutoCorresSEL4 session

### DIFF
--- a/.github/workflows/proofs.yml
+++ b/.github/workflows/proofs.yml
@@ -26,6 +26,7 @@ jobs:
         manifest: manifest.xml
         cache_name: seL4/l4v-default-devel-${{ matrix.arch }}
         cache_write: ''
+        session: '-x AutoCorresSEL4'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This session was excluded by default from within `seL4/ci-actions/aws-proofs` before, but is now needed explicitly.

Only the testboard really needs to do this, all other calls were either providing specific sessions anyway or were overriding the exclusion.

Needs seL4/ci-actions#206
